### PR TITLE
Add responsemean rule

### DIFF
--- a/mrtproc/config/snakebids.yml
+++ b/mrtproc/config/snakebids.yml
@@ -123,6 +123,7 @@ parse_args:
   --responsemean_dir:
     help: Provide directory containing average response functions. If not provided,
       one will be computed from the subjects in the input directory.
+    default: None
 
 #-----------------------------------------------------#
 

--- a/mrtproc/workflow/Snakefile
+++ b/mrtproc/workflow/Snakefile
@@ -25,7 +25,7 @@ wildcard_constraints:
 
 root = os.path.join(config["root"], "mrtrix")
 
-responsemean_flag = True if config.get('responsemean_dir', None) else False
+responsemean_flag = True if config['responsemean_dir'] else False
 
 # ---- end snakebids boilerplate ------------------------------------------------
 


### PR DESCRIPTION
This PR adds in and updates rules to compute a group average response function:

* adds `rule responsemean` which performs the averaging of response functions
* adds `group:` definitions (`subj1`, `subj2`, `group`)
* adds flag for user to input directory containing response functions -> workflow to use existing functions if provided, else compute new ones